### PR TITLE
Image search

### DIFF
--- a/frontend/components.json
+++ b/frontend/components.json
@@ -11,7 +11,7 @@
     "prefix": ""
   },
   "aliases": {
-    "components": "/src/components/shadcn/",
-    "utils": "/src/lib/utils"
+    "components": "src/components/shadcn/",
+    "utils": "src/lib/utils"
   }
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "@radix-ui/react-alert-dialog": "^1.1.1",
         "@radix-ui/react-icons": "^1.3.0",
         "@radix-ui/react-label": "^2.1.0",
+        "@radix-ui/react-menubar": "^1.1.1",
         "@radix-ui/react-select": "^2.1.1",
         "@radix-ui/react-slot": "^1.1.0",
         "@testing-library/jest-dom": "^5.17.0",
@@ -3810,6 +3811,76 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-menu": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.1.tgz",
+      "integrity": "sha512-oa3mXRRVjHi6DZu/ghuzdylyjaMXLymx83irM7hTxutQbD+7IhPKdMdRHD26Rm+kHRrWcrUkkRPv5pd47a2xFQ==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-collection": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-context": "1.1.0",
+        "@radix-ui/react-direction": "1.1.0",
+        "@radix-ui/react-dismissable-layer": "1.1.0",
+        "@radix-ui/react-focus-guards": "1.1.0",
+        "@radix-ui/react-focus-scope": "1.1.0",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-popper": "1.2.0",
+        "@radix-ui/react-portal": "1.1.1",
+        "@radix-ui/react-presence": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-roving-focus": "1.1.0",
+        "@radix-ui/react-slot": "1.1.0",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "aria-hidden": "^1.1.1",
+        "react-remove-scroll": "2.5.7"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menubar": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menubar/-/react-menubar-1.1.1.tgz",
+      "integrity": "sha512-V05Hryq/BE2m+rs8d5eLfrS0jmSWSDHEbG7jEyLA5D5J9jTvWj/o3v3xDN9YsOlH6QIkJgiaNDaP+S4T1rdykw==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-collection": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-context": "1.1.0",
+        "@radix-ui/react-direction": "1.1.0",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-menu": "2.1.1",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-roving-focus": "1.1.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-popper": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.0.tgz",
@@ -3893,6 +3964,36 @@
       "integrity": "sha512-ZSpFm0/uHa8zTvKBDjLFWLo8dkr4MBsiDLz0g3gMUwqgLHz9rTaRRGYDgvZPtBJgYCBKXkS9fzmoySgr8CO6Cw==",
       "dependencies": {
         "@radix-ui/react-slot": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.0.tgz",
+      "integrity": "sha512-EA6AMGeq9AEeQDeSH0aZgG198qkfHSbvWTf1HvoDmOB5bBG/qTxjYMWUKMnYiV6J/iP/J8MEFSuB2zRU2n7ODA==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-collection": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-context": "1.1.0",
+        "@radix-ui/react-direction": "1.1.0",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "@radix-ui/react-alert-dialog": "^1.1.1",
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-label": "^2.1.0",
+    "@radix-ui/react-menubar": "^1.1.1",
     "@radix-ui/react-select": "^2.1.1",
     "@radix-ui/react-slot": "^1.1.0",
     "@testing-library/jest-dom": "^5.17.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,18 +6,47 @@ import ImagePinFormPage from './pages/ImagePinFormPage';
 import ImagePinDetailPage from './pages/ImagePinDetailPage';
 import LoginPage from './pages/LoginPage';
 import JoinPage from './pages/JoinPage';
+import Layout from './Layout';
 
 function App() {
   return (
     <div className="App">
       <BrowserRouter>
         <Routes>
-          <Route path="/" element={<HomePage/>}></Route>
-          <Route path="/login" element={<LoginPage/>}></Route>
-          <Route path="/join" element={<JoinPage/>}></Route>
-          <Route path="/search"element={<SearchPage/>}></Route>
-          <Route path="/make-image-pin" element={<ImagePinFormPage/>}></Route>
-          <Route path="/image-pin-detail" element={<ImagePinDetailPage/>}></Route>
+          <Route
+            path="/"
+            element={
+              <Layout>
+                <HomePage />
+              </Layout>
+            }
+          ></Route>
+          <Route path="/login" element={<LoginPage />}></Route>
+          <Route path="/join" element={<JoinPage />}></Route>
+          <Route
+            path="/search/:searchWord"
+            element={
+              <Layout>
+                <SearchPage />
+              </Layout>
+            }
+          ></Route>
+          <Route
+            path="/make-image-pin"
+            element={
+              <Layout>
+                <ImagePinFormPage />
+              </Layout>
+            }
+          ></Route>
+          <Route
+            path="/image-pin-detail"
+            element={
+              <Layout>
+                <ImagePinDetailPage />
+              </Layout>
+            }
+          ></Route>
         </Routes>
       </BrowserRouter>
     </div>

--- a/frontend/src/Layout.tsx
+++ b/frontend/src/Layout.tsx
@@ -1,0 +1,16 @@
+import MainMenu from "./components/menu/MainMenu";
+
+interface Props {
+    children: React.ReactNode;
+}
+
+function Layout({ children }: Props) {
+    return (
+      <div>
+        <MainMenu />
+        <main>{children}</main>
+      </div>
+    );
+  }
+
+  export default Layout;

--- a/frontend/src/api/image.api.ts
+++ b/frontend/src/api/image.api.ts
@@ -1,6 +1,6 @@
 import { commonValue } from './common.value';
-import { ErrorResponse, Response } from './types/common.data.type';
-import { MainImage } from './types/image.data.type';
+import { ErrorResponse, Response, ResponseCallback } from './types/common.data.type';
+import { MainImage, SearchImage } from './types/image.data.type';
 
 const PREFIX_URL = '/image';
 
@@ -25,6 +25,42 @@ export async function getMainImages(
 }
 
 function mainImageDataAdaptor(res: MainImageResponse): Response<MainImage> {
+  return {
+    data: {
+      images:
+        res.map((d) => ({
+          id: d.id,
+          url: d.url,
+        })),
+    },
+    success: true,
+  };
+}
+
+type SearchImageResponse = { id: number; url: string }[];
+
+export async function getSearchImages(
+  searchWord: string,
+  callback: ResponseCallback<SearchImage>,
+) {
+  try {
+    const params = new URLSearchParams({ 'search-word': searchWord }).toString();
+    const url = `${commonValue.ORIGIN}${PREFIX_URL}/search?${params}`;
+    const result = await fetch(url, {
+      headers: {
+        'Content-Type': 'application/json',
+        [commonValue.TOKEN_HEADER]: commonValue.ACCESS_TOKEN,
+      },
+      credentials: "include",
+    }).then((res) => res.json());
+
+    callback(searchImageDataAdaptor(result));
+  } catch {
+    callback({ data: null, errorMessage: '이미지 로드 실패', success: false });
+  }
+}
+
+function searchImageDataAdaptor(res: SearchImageResponse): Response<SearchImage> {
   return {
     data: {
       images:

--- a/frontend/src/api/types/common.data.type.ts
+++ b/frontend/src/api/types/common.data.type.ts
@@ -8,3 +8,5 @@ export interface Response<T> {
     data: T;
     success: boolean;
 }
+
+export type ResponseCallback<T> = (data: Response<T> | ErrorResponse) => void;

--- a/frontend/src/api/types/image.data.type.ts
+++ b/frontend/src/api/types/image.data.type.ts
@@ -7,3 +7,4 @@ export interface ImagePins {
 }
 
 export type MainImage = ImagePins;
+export type SearchImage = ImagePins;

--- a/frontend/src/components/image/ImagePinList.tsx
+++ b/frontend/src/components/image/ImagePinList.tsx
@@ -1,28 +1,15 @@
-import { useEffect, useState } from 'react';
 import ImagePin from './ImagePin';
 import { ErrorResponse, Response } from '@/src/api/types/common.data.type';
 import { ImagePins } from '@/src/api/types/image.data.type';
 import EmptyImagePin from './EmptyImagePin';
 
 interface Props {
-  getDataFunc: (
-    callback: (res: ErrorResponse | Response<ImagePins>) => void,
-  ) => void;
+  imageDatas: ErrorResponse | Response<ImagePins> | undefined;
 }
 
-function ImagePinList({ getDataFunc }: Props) {
-  const [imageDatas, setImageDatas] = useState<
-    ErrorResponse | Response<ImagePins>
-  >();
-
-  useEffect(() => {
-    getDataFunc((res) => {
-      setImageDatas(res);
-    });
-  }, []);
-
+function ImagePinList({ imageDatas }: Props) {
   const isErrorResponse = (
-    response: ErrorResponse | Response<ImagePins> | undefined,
+    response: Response<ImagePins> | ErrorResponse | undefined,
   ): response is ErrorResponse => {
     return !!response && response.success === false;
   };

--- a/frontend/src/components/menu/MainMenu.tsx
+++ b/frontend/src/components/menu/MainMenu.tsx
@@ -1,0 +1,56 @@
+import { useLocation, useNavigate } from 'react-router-dom';
+import { Menubar, MenubarMenu, MenubarTrigger } from '../shadcn/ui/menubar';
+import SearchInput from './SearchInput';
+import { useEffect, useState } from 'react';
+
+function MainMenu() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const [homeBg, setHomeBg] = useState('');
+  const [makeImagePinBg, setMakeImagePinBg] = useState('');
+  const buttonClasses = "h-12 min-w-[60px] px-[8px] py-0 rounded-full flex justify-center";
+
+  const toHomePage = () => {
+    navigate('/');
+  };
+  const toImagePinFormPage = () => {
+    navigate('/make-image-pin');
+  };
+
+  useEffect(() => {
+    if (location.pathname === '/') {
+      setHomeBg('bg-black text-white');
+    } else {
+      setHomeBg('bg-transperant text-black');
+    }
+    if (location.pathname === '/make-image-pin') {
+      setMakeImagePinBg('bg-black text-white');
+    } else {
+      setMakeImagePinBg('bg-transperant text-black');
+    }
+  }, [location.pathname]);
+
+  return (
+    <div>
+      <Menubar className="h-[80px]">
+        <MenubarMenu>
+          <MenubarTrigger
+            className={`${buttonClasses} ${homeBg}`}
+            onClick={toHomePage}
+          >
+            <div>홈</div>
+          </MenubarTrigger>
+          <MenubarTrigger
+            className={`${buttonClasses} ${makeImagePinBg}`}
+            onClick={toImagePinFormPage}
+          >
+            <div>만들기</div>
+          </MenubarTrigger>
+          <SearchInput className="grow"></SearchInput>
+        </MenubarMenu>
+      </Menubar>
+    </div>
+  );
+}
+
+export default MainMenu;

--- a/frontend/src/components/menu/SearchInput.tsx
+++ b/frontend/src/components/menu/SearchInput.tsx
@@ -1,0 +1,31 @@
+import { useNavigate } from 'react-router-dom';
+import { KeyboardEvent, useState } from 'react';
+
+interface Props {
+  className?: string;
+}
+
+function SearchInput({ className = '' }: Props) {
+  const navigate = useNavigate();
+  const [value, setValue] = useState<string>();
+
+  const inputHandler = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && value) {
+      navigate(`/search/${value}`);
+    }
+  };
+
+  return (
+    <div className={className}>
+      <input
+        className='w-full h-[48px] bg-[rgb(241,241,241)] rounded-full px-[16px]'
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onKeyDown={inputHandler}
+        placeholder="검색"
+      />
+    </div>
+  );
+}
+
+export default SearchInput;

--- a/frontend/src/components/shadcn/ui/menubar.tsx
+++ b/frontend/src/components/shadcn/ui/menubar.tsx
@@ -1,0 +1,236 @@
+"use client"
+
+import * as React from "react"
+import * as MenubarPrimitive from "@radix-ui/react-menubar"
+import { Check, ChevronRight, Circle } from "lucide-react"
+
+import { cn } from "src/lib/utils"
+
+const MenubarMenu = MenubarPrimitive.Menu
+
+const MenubarGroup = MenubarPrimitive.Group
+
+const MenubarPortal = MenubarPrimitive.Portal
+
+const MenubarSub = MenubarPrimitive.Sub
+
+const MenubarRadioGroup = MenubarPrimitive.RadioGroup
+
+const Menubar = React.forwardRef<
+  React.ElementRef<typeof MenubarPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof MenubarPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <MenubarPrimitive.Root
+    ref={ref}
+    className={cn(
+      "flex h-10 items-center space-x-1 rounded-md border bg-background p-1",
+      className
+    )}
+    {...props}
+  />
+))
+Menubar.displayName = MenubarPrimitive.Root.displayName
+
+const MenubarTrigger = React.forwardRef<
+  React.ElementRef<typeof MenubarPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof MenubarPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <MenubarPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "flex cursor-default select-none items-center rounded-sm px-3 py-1.5 text-sm font-medium outline-none",
+      className
+    )}
+    {...props}
+  />
+))
+MenubarTrigger.displayName = MenubarPrimitive.Trigger.displayName
+
+const MenubarSubTrigger = React.forwardRef<
+  React.ElementRef<typeof MenubarPrimitive.SubTrigger>,
+  React.ComponentPropsWithoutRef<typeof MenubarPrimitive.SubTrigger> & {
+    inset?: boolean
+  }
+>(({ className, inset, children, ...props }, ref) => (
+  <MenubarPrimitive.SubTrigger
+    ref={ref}
+    className={cn(
+      "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground",
+      inset && "pl-8",
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <ChevronRight className="ml-auto h-4 w-4" />
+  </MenubarPrimitive.SubTrigger>
+))
+MenubarSubTrigger.displayName = MenubarPrimitive.SubTrigger.displayName
+
+const MenubarSubContent = React.forwardRef<
+  React.ElementRef<typeof MenubarPrimitive.SubContent>,
+  React.ComponentPropsWithoutRef<typeof MenubarPrimitive.SubContent>
+>(({ className, ...props }, ref) => (
+  <MenubarPrimitive.SubContent
+    ref={ref}
+    className={cn(
+      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      className
+    )}
+    {...props}
+  />
+))
+MenubarSubContent.displayName = MenubarPrimitive.SubContent.displayName
+
+const MenubarContent = React.forwardRef<
+  React.ElementRef<typeof MenubarPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof MenubarPrimitive.Content>
+>(
+  (
+    { className, align = "start", alignOffset = -4, sideOffset = 8, ...props },
+    ref
+  ) => (
+    <MenubarPrimitive.Portal>
+      <MenubarPrimitive.Content
+        ref={ref}
+        align={align}
+        alignOffset={alignOffset}
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 min-w-[12rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          className
+        )}
+        {...props}
+      />
+    </MenubarPrimitive.Portal>
+  )
+)
+MenubarContent.displayName = MenubarPrimitive.Content.displayName
+
+const MenubarItem = React.forwardRef<
+  React.ElementRef<typeof MenubarPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof MenubarPrimitive.Item> & {
+    inset?: boolean
+  }
+>(({ className, inset, ...props }, ref) => (
+  <MenubarPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      inset && "pl-8",
+      className
+    )}
+    {...props}
+  />
+))
+MenubarItem.displayName = MenubarPrimitive.Item.displayName
+
+const MenubarCheckboxItem = React.forwardRef<
+  React.ElementRef<typeof MenubarPrimitive.CheckboxItem>,
+  React.ComponentPropsWithoutRef<typeof MenubarPrimitive.CheckboxItem>
+>(({ className, children, checked, ...props }, ref) => (
+  <MenubarPrimitive.CheckboxItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    checked={checked}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <MenubarPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </MenubarPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </MenubarPrimitive.CheckboxItem>
+))
+MenubarCheckboxItem.displayName = MenubarPrimitive.CheckboxItem.displayName
+
+const MenubarRadioItem = React.forwardRef<
+  React.ElementRef<typeof MenubarPrimitive.RadioItem>,
+  React.ComponentPropsWithoutRef<typeof MenubarPrimitive.RadioItem>
+>(({ className, children, ...props }, ref) => (
+  <MenubarPrimitive.RadioItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <MenubarPrimitive.ItemIndicator>
+        <Circle className="h-2 w-2 fill-current" />
+      </MenubarPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </MenubarPrimitive.RadioItem>
+))
+MenubarRadioItem.displayName = MenubarPrimitive.RadioItem.displayName
+
+const MenubarLabel = React.forwardRef<
+  React.ElementRef<typeof MenubarPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof MenubarPrimitive.Label> & {
+    inset?: boolean
+  }
+>(({ className, inset, ...props }, ref) => (
+  <MenubarPrimitive.Label
+    ref={ref}
+    className={cn(
+      "px-2 py-1.5 text-sm font-semibold",
+      inset && "pl-8",
+      className
+    )}
+    {...props}
+  />
+))
+MenubarLabel.displayName = MenubarPrimitive.Label.displayName
+
+const MenubarSeparator = React.forwardRef<
+  React.ElementRef<typeof MenubarPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof MenubarPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <MenubarPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    {...props}
+  />
+))
+MenubarSeparator.displayName = MenubarPrimitive.Separator.displayName
+
+const MenubarShortcut = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLSpanElement>) => {
+  return (
+    <span
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+MenubarShortcut.displayname = "MenubarShortcut"
+
+export {
+  Menubar,
+  MenubarMenu,
+  MenubarTrigger,
+  MenubarContent,
+  MenubarItem,
+  MenubarSeparator,
+  MenubarLabel,
+  MenubarCheckboxItem,
+  MenubarRadioGroup,
+  MenubarRadioItem,
+  MenubarPortal,
+  MenubarSubContent,
+  MenubarSubTrigger,
+  MenubarGroup,
+  MenubarSub,
+  MenubarShortcut,
+}

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,12 +1,23 @@
+import { useEffect, useState } from 'react';
 import { getMainImages } from '../api/image.api';
 import ImagePinList from '../components/image/ImagePinList';
+import { ErrorResponse, Response } from '../api/types/common.data.type';
+import { ImagePins } from '../api/types/image.data.type';
 
 function HomePage() {
-    // TODO: 로그인 확인 후 안되어있다면 리다이렉션. -> /login.
+  const [imageDatas, setImageDatas] = useState<
+    Response<ImagePins> | ErrorResponse
+  >();
+
+  useEffect(() => {
+    getMainImages((res) => {
+      setImageDatas(res);
+    })
+  }, []);
 
   return (
     <div>
-      <ImagePinList getDataFunc={getMainImages}></ImagePinList>
+      <ImagePinList imageDatas={imageDatas}></ImagePinList>
     </div>
   );
 }

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -1,6 +1,36 @@
+import { useNavigate, useParams } from 'react-router-dom';
+import { getSearchImages } from '../api/image.api';
+import ImagePinList from '../components/image/ImagePinList';
+import { ImagePins, SearchImage } from '../api/types/image.data.type';
+import { ErrorResponse, Response, ResponseCallback } from '../api/types/common.data.type';
+import { useEffect, useState } from 'react';
+
 function SearchPage() {
+  const param = useParams();
+  const [imageDatas, setImageDatas] = useState<
+    Response<ImagePins> | ErrorResponse
+  >();
+
+  const requestSearchImages = (searchWord: string) => {
+    if (!searchWord || searchWord === '') useNavigate()('/');
+    const callback: ResponseCallback<SearchImage> = (res) => {
+      setImageDatas(res);
+    }
+
+    getSearchImages(searchWord, callback);
+  };
+
+  useEffect(() => {
+    requestSearchImages(param.searchWord || '');
+  }, []);
+  useEffect(() => {
+    requestSearchImages(param.searchWord || '');
+  }, [param.searchWord]);
+
   return (
-   <div></div>
+    <div>
+      <ImagePinList imageDatas={imageDatas}></ImagePinList>
+    </div>
   );
 }
 export default SearchPage;


### PR DESCRIPTION
- close #20 
- close #21 
- layout 컴포넌트 : Menubar와 같이 
- image pin list 컴포넌트 변경
getDataFunc를 Props로 받아서 image pin list 컴포넌트에서 직접 데이터를 호출해서 state로 저장하고 있었다.
그런데 이 방식은 문제가 있었다.
1. 이미지를 호출하는 API에 전달해야하는 인자 값이 달라질 수 있다는 문제 -> API 호출 방식이 받아올 이미지의 종류에 따라 달라질 수 있음.
2. 이미지 데이터가 업데이트 되는 시점이 image pin list가 최초 렌더링 되는 시점에 한정됨. -> 기존 코드를 보면 userEffect를 사용해서 image pin list가 최초 렌더링 될 때 데이터를 받아온다.
이렇게 되면 이미지를 페이지 내부에서 새로 받아와야하는 상황이 생길 때 이미 데이터 호출 시점이 고정되어 있어서 수정할 수 없다는 문제가 있다.

그래서 이미지를 직접 image pin list 컴포넌트에서 호출하지 않고, 상위 컴포넌트(재사용되지 않는)에서 호출한 뒤 image pin list 컴포넌트에 데이터를 내려주는 형태로 변경했다.
