### PR TITLE
Refactor image pin list component

### DIFF
--- a/frontend/src/components/image/ImagePinList.tsx
+++ b/frontend/src/components/image/ImagePinList.tsx
@@ -1,34 +1,23 @@
 import ImagePin from './ImagePin';
-import { ErrorResponse, Response } from '@/src/api/types/common.data.type';
 import { ImagePins } from '@/src/api/types/image.data.type';
 import EmptyImagePin from './EmptyImagePin';
 
 interface Props {
-  imageDatas: ErrorResponse | Response<ImagePins> | undefined;
+  imageDatas: ImagePins;
 }
 
 function ImagePinList({ imageDatas }: Props) {
-  const isErrorResponse = (
-    response: Response<ImagePins> | ErrorResponse | undefined,
-  ): response is ErrorResponse => {
-    return !!response && response.success === false;
-  };
-
   return (
-    <div className="flex flex-wrap justify-center">
-      {!imageDatas && <div>loading...</div>}
-      {isErrorResponse(imageDatas) && <div>{imageDatas.errorMessage}</div>}
-      {imageDatas &&
-        imageDatas.success &&
-        imageDatas?.data?.images?.map((value, index) => {
-          if (!value) return <EmptyImagePin key={index} />;
+    <>
+      {imageDatas.images?.map((value, index) => {
+        if (!value) return <EmptyImagePin key={index} />;
 
-          const { id, url } = value;
-          if (!id || !url) return <EmptyImagePin key={index} />;
+        const { id, url } = value;
+        if (!id || !url) return <EmptyImagePin key={index} />;
 
-          return <ImagePin key={id} id={id} url={url}></ImagePin>;
-        })}
-    </div>
+        return <ImagePin key={id} id={id} url={url}></ImagePin>;
+      })}
+    </>
   );
 }
 

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -12,12 +12,22 @@ function HomePage() {
   useEffect(() => {
     getMainImages((res) => {
       setImageDatas(res);
-    })
+    });
   }, []);
 
+  const isErrorResponse = (
+    response: Response<ImagePins> | ErrorResponse | undefined,
+  ): response is ErrorResponse => {
+    return !!response && response.success === false;
+  };
+
   return (
-    <div>
-      <ImagePinList imageDatas={imageDatas}></ImagePinList>
+    <div className="w-full flex flex-row flex-wrap justify-center">
+      {!imageDatas && <div>loading...</div>}
+      {isErrorResponse(imageDatas) && <div>{imageDatas.errorMessage}</div>}
+      {imageDatas && imageDatas.success && imageDatas.data && (
+        <ImagePinList imageDatas={imageDatas.data}></ImagePinList>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/ImagePinDetailPage.tsx
+++ b/frontend/src/pages/ImagePinDetailPage.tsx
@@ -5,8 +5,13 @@ import { deleteImagePin, getImageDetails } from '../api/image.api';
 import { ErrorResponse, Response } from '../api/types/common.data.type';
 import { ImageDetailsInfo } from '../api/types/image.data.type';
 import Loading from '../components/common/Loading';
-import { createSaveImage, deleteSaveImage, getSaveImage } from '../api/saveimage.api';
+import {
+  createSaveImage,
+  deleteSaveImage,
+  getSaveImage,
+} from '../api/saveimage.api';
 import { SaveImageInfo } from '../api/types/saveimage.data.type';
+import ImagePinList from '../components/image/ImagePinList';
 
 function ImagePinDetailPage() {
   const param = useParams();
@@ -104,6 +109,16 @@ function ImagePinDetailPage() {
           createSaveImage={requesToCreateSaveImage}
           deleteSaveImage={requesToDeleteSaveImage}
         ></ImagePinDetail>
+      )}
+      {imageDetails?.data?.imageDetails?.moreImages && (
+        <>
+          <h3 className='mt-3 mb-1 text-[20px] font-medium'>더 찾아보기</h3>
+          <div className="flex flex-wrap justify-center">
+            <ImagePinList
+              imageDatas={imageDetails.data.imageDetails.moreImages}
+            ></ImagePinList>
+          </div>
+        </>
       )}
     </div>
   );

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -11,6 +11,13 @@ function SearchPage() {
     Response<ImagePins> | ErrorResponse
   >();
 
+  useEffect(() => {
+    requestSearchImages(param.searchWord || '');
+  }, []);
+  useEffect(() => {
+    requestSearchImages(param.searchWord || '');
+  }, [param.searchWord]);
+
   const requestSearchImages = (searchWord: string) => {
     if (!searchWord || searchWord === '') useNavigate()('/');
     const callback: ResponseCallback<SearchImage> = (res) => {
@@ -20,16 +27,19 @@ function SearchPage() {
     getSearchImages(searchWord, callback);
   };
 
-  useEffect(() => {
-    requestSearchImages(param.searchWord || '');
-  }, []);
-  useEffect(() => {
-    requestSearchImages(param.searchWord || '');
-  }, [param.searchWord]);
+  const isErrorResponse = (
+    response: Response<ImagePins> | ErrorResponse | undefined,
+  ): response is ErrorResponse => {
+    return !!response && response.success === false;
+  };
 
   return (
-    <div>
-      <ImagePinList imageDatas={imageDatas}></ImagePinList>
+    <div className="w-full flex flex-wrap justify-center">
+      {!imageDatas && <div>loading...</div>}
+      {isErrorResponse(imageDatas) && <div>{imageDatas.errorMessage}</div>}
+      {imageDatas?.success && imageDatas.data && (
+      <ImagePinList imageDatas={imageDatas.data}></ImagePinList>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
- Image Pin List 컴포넌트 범용성 확장
데이터 받던 형식을 서버 API로 부터 받은 데이터를 감싸던 Response 인터페이스 형식에서 일반 데이터 형식으로 바꿨다.
이전에는 Image Pin List UI 내부에서 서버 데이터 요청 결과에 따라 다른 화면을 보여주는 역할까지 하고 있었다.
그래서 Image Pin UI를 여러 개를 데이터를 받아서 출력한다는 컴포넌트의 목적 이외의 하나의 역할을 더 하고 있던 문제가 있었다.
또한, 이미지, 다른 데이터를 함께 서버에서 들고오는 경우에 불필요한 Response 타입으로 Image 데이터를 랩핑해야하는 문제가 있었다.
서비스의 다양한 페이지에서 사용될 수 있는 UI인 만큼 image 데이터 자체만 받게 바꿔서 더 범용성있게 사용할 수 있는 컴포넌트로 변경해주었다.