### PR TITLE
Fix category command

### DIFF
--- a/frontend/src/components/category/CategoryCombobox.tsx
+++ b/frontend/src/components/category/CategoryCombobox.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { SyntheticEvent, useState } from 'react';
 import {
   Command,
   CommandEmpty,
@@ -19,8 +19,10 @@ interface Props {
 function CategoryCombobox({ selectHandler, items }: Props) {
   const [open, setOpen] = useState(false);
 
-  const selectCommandItemHandler = (value: string) => {
-    selectHandler(Number.parseInt(value));
+  const clickHandler = (e: SyntheticEvent<HTMLDivElement>) => {
+    const target = e.target as HTMLDivElement;
+    if (!target.dataset['id']) return; // todo 알수 없는 에러 alert 띄우기.
+    selectHandler(Number.parseInt(target.dataset['id']));
     setOpen(false);
   };
 
@@ -31,20 +33,22 @@ function CategoryCombobox({ selectHandler, items }: Props) {
       </PopoverTrigger>
       <PopoverContent className="w-[200px] p-0">
         <Command className="rounded-lg border shadow-md">
-          <CommandInput placeholder="Search framework..." className="h-9" />
+          <CommandInput placeholder="태그 검색" className="h-9" />
           <CommandList>
             <CommandEmpty>결과를 찾을 수 없습니다.</CommandEmpty>
-            <CommandGroup heading="일치 태그">
-              {items.map((item) => (
-                <CommandItem
-                  key={item.id}
-                  value={item.id.toString()}
-                  onSelect={selectCommandItemHandler}
-                >
-                  {item.name}
-                </CommandItem>
-              ))}
-            </CommandGroup>
+            {items && (
+              <CommandGroup heading="일치 태그" onClick={clickHandler}>
+                {items.map((item) => (
+                  <CommandItem
+                    key={item.id}
+                    value={item.name}
+                    data-id={item.id}
+                  >
+                    {item.name}
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            )}
           </CommandList>
         </Command>
       </PopoverContent>


### PR DESCRIPTION
- shardcn의 검색을 지원하는 command 컴포넌트에서 command item으로 입력한 category 목록이 검색되지 않는 문제 해결
태그 안의 text값이 아니라 value 속성을 통해 내부적으로 검색을 구현하고 있었다.
내가 이 값을 id 값으로 주어 검색이 되지 않았다.
그래서 따로 dataset을 이용해 id 속성을 저장해주었고 value는 카테고리 명으로 지정하였다.