### PR TITLE
React router loader 적용

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import './App.css';
 import HomePage from './pages/HomePage';
 import SearchPage from './pages/SearchPage';
@@ -11,54 +11,71 @@ import { UserProvider } from './context/UserContext';
 import PrivateRoute from './components/common/PrivateRoute';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import { getMainImages } from './api/image.api';
+import { commonValue } from './common.value';
 
 function App() {
   const queryClient = new QueryClient();
+  const mainImageLoader = () => {
+    if (!visualViewport) throw new Error();
+    const size = commonValue.IMAGE_DATA_PAGE_SIZE(visualViewport);
+
+    return getMainImages({ size, page: 1 });
+  }
+  const router = createBrowserRouter([
+    {
+      path: '/login',
+      element: <LoginPage />,
+    },
+    {
+      path: '/join',
+      element: <JoinPage />,
+    },
+    {
+      element: <PrivateRoute />,
+      children: [
+        {
+          path: '/',
+          element: (
+            <Layout>
+              <HomePage />
+            </Layout>
+          ),
+          loader: mainImageLoader
+        },
+        {
+          path: '/search/:searchWord',
+          element: (
+            <Layout>
+              <SearchPage />
+            </Layout>
+          ),
+        },
+        {
+          path: '/make-image-pin',
+          element: (
+            <Layout>
+              <ImagePinFormPage />
+            </Layout>
+          ),
+        },
+        {
+          path: '/image-pin-detail/:id',
+          element: (
+            <Layout>
+              <ImagePinDetailPage />
+            </Layout>
+          ),
+        },
+      ],
+    },
+  ]);
 
   return (
     <QueryClientProvider client={queryClient}>
       <UserProvider>
         <div className="App">
-          <BrowserRouter>
-            <Routes>
-              <Route path="/login" element={<LoginPage />}></Route>
-              <Route path="/join" element={<JoinPage />}></Route>
-              <Route element={<PrivateRoute />}>
-                <Route
-                  path="/"
-                  element={
-                    <Layout>
-                      <HomePage />
-                    </Layout>
-                  }
-                ></Route>
-                <Route
-                  path="/search/:searchWord"
-                  element={
-                    <Layout>
-                      <SearchPage />
-                    </Layout>
-                  }
-                ></Route>
-                <Route
-                  path="/make-image-pin"
-                  element={
-                    <Layout>
-                      <ImagePinFormPage />
-                    </Layout>
-                  }
-                ></Route>
-                <Route
-                  path="/image-pin-detail/:id"
-                  element={
-                    <Layout>
-                      <ImagePinDetailPage />
-                    </Layout>
-                  }
-                ></Route>
-              </Route>
-            </Routes>
-          </BrowserRouter>
+          <RouterProvider router={router} />
         </div>
       </UserProvider>
       <ReactQueryDevtools initialIsOpen={true} />

--- a/frontend/src/api/image.api.ts
+++ b/frontend/src/api/image.api.ts
@@ -81,9 +81,8 @@ type ImageReplyResponse = {
 
 export async function getMainImages(
   paginationParams: PaginationParams,
-  callback: (data: Response<MainImage> | ErrorResponse) => void,
   seed?: number,
-) {
+): Promise<Response<MainImage> | ErrorResponse> {
   validatePaginationParams(paginationParams);
   if (seed) validateSeedParams(seed);
 
@@ -106,9 +105,9 @@ export async function getMainImages(
       return res.json();
     });
 
-    callback(mainImageDataAdaptor(result));
+    return mainImageDataAdaptor(result);
   } catch {
-    callback({ data: null, errorMessage: '이미지 로드 실패', success: false });
+    return { data: null, errorMessage: '이미지 로드 실패', success: false };
   }
 }
 


### PR DESCRIPTION
- home page image 데이터 서버로부터 가져올 때 loader 적용.
home page는 매번 접속 시 랜덤 데이터를 가져온다.
최초 useEffect 실행 후 main image를 가져온다. useEffect 실행 전에는 기본적으로 렌더링되는 기본 화면이 있다.
기본 UI 렌더링 시간을 줄이고 페이지 접근 시 가져온 image 데이터를 바탕으로 바로 렌더링을 진행한다.